### PR TITLE
Install to the correct global VST3 path on Linux

### DIFF
--- a/Builds/LinuxMakefile/install.sh
+++ b/Builds/LinuxMakefile/install.sh
@@ -23,8 +23,8 @@ mkdir -p ${PREFIX}/share/pixmaps
 cp  ../../images/sonobus_logo@2x.png ${PREFIX}/share/pixmaps/sonobus.png
 
 if [ -d build/SonoBus.vst3 ] ; then
-  mkdir -p ${PREFIX}/lib/lxvst
-  cp -a build/SonoBus.vst3 ${PREFIX}/lib/lxvst/
+  mkdir -p ${PREFIX}/lib/vst3
+  cp -a build/SonoBus.vst3 ${PREFIX}/lib/vst3/
 
   echo "SonoBus VST3 plugin installed"
 fi

--- a/Builds/LinuxMakefile/uninstall.sh
+++ b/Builds/LinuxMakefile/uninstall.sh
@@ -16,6 +16,6 @@ fi
 
 rm -f ${PREFIX}/share/applications/sonobus.desktop
 rm -f ${PREFIX}/pixmaps/sonobus.png
-rm -rf ${PREFIX}/lib/lxvst/SonoBus.vst3
+rm -rf ${PREFIX}/lib/vst3/SonoBus.vst3
 
 echo "SonoBus uninstalled"


### PR DESCRIPTION
I just tried out SonoBus for the first time after having tried a lot of other real time audio sharing solutions, and I'm very impressed! I did notice that the install script installs the VST3 plugin to the wrong directory, so no Linux VST3 host will pick the plugin up. On Linux the correct global VST3 plugin location is `/usr/lib/vst3`. This tiny patch changes the installation directories for the VST3 plugin in the install and uninstall scripts. See the VST3 docs for more information: https://steinbergmedia.github.io/vst3_doc/vstinterfaces/vst3loc.html#linuxlocation