### PR TITLE
Create Fedora prerequisite shell script

### DIFF
--- a/Builds/LinuxMakefile/fedora_get_prereqs.sh
+++ b/Builds/LinuxMakefile/fedora_get_prereqs.sh
@@ -25,7 +25,5 @@ echo ""
 
 sudo dnf update
 sudo dnf -y groupinstall "Development Tools" "Development Libraries"
-sudo dnf -y install git $PREREQS 
-
-
+sudo dnf -y install git $PREREQS
 

--- a/Builds/LinuxMakefile/fedora_get_prereqs.sh
+++ b/Builds/LinuxMakefile/fedora_get_prereqs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Install prerequisite packages for SonoBus build on Fedora
+
+GITREPO="https://github.com/essej/sonobus.git"
+
+PREREQS="libopusenc \
+	libopusenc-devel \
+	jack-audio-connection-kit \
+	jack-audio-connection-kit-devel \
+	alsa-lib-devel \
+	libX11-devel \
+	libXext-devel \
+	libXinerama-devel \
+	libXrandr-devel \
+	libXcursor-devel \
+	mesa-libGL-devel \
+	freetype-devel \
+	libcurl-devel
+        "
+
+echo ""
+echo "Installing prerequisites - " $(date)
+echo ""
+
+sudo dnf update
+sudo dnf -y groupinstall "Development Tools" "Development Libraries"
+sudo dnf -y install git $PREREQS 
+
+
+

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Other distributions may have slightly different package names for these, for
 instance in Debian, you might substitute libcurl4-gnutls-dev.
 
 If you are using Ubuntu, you can run the following script to install all the
-prequisites (scripts for other distributions wanted, please contribute them
+prerequisites (scripts for other distributions wanted, please contribute them
 if you can):
 
     ./ubuntu_get_prereqs.sh


### PR DESCRIPTION
Created a script to install the prerequisite packages on Fedora with DNF.

I had to substitute several of the packages that were suggested for Ubuntu for ones that were available in this distro. I'm using Fedora 33 Workstation and this script worked fine for me - the program complied perfectly. 

Do let me know if I've done something glaringly wrong - I'm not that knowledgeable about Linux and am new to open source in general!