### PR TITLE
Default Sound Quality Tooltip about Opus vs PCM

### DIFF
--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -683,6 +683,7 @@ SonobusAudioProcessorEditor::SonobusAudioProcessorEditor (SonobusAudioProcessor&
     for (int i=0; i < numformats; ++i) {
         mOptionsFormatChoiceDefaultChoice->addItem(processor.getAudioCodeFormatName(i), i+1);
     }
+    mOptionsFormatChoiceDefaultChoice->setTooltip(TRANS("Opus compression adds 5 ms latency and can't benefit by reducing Audio Buffer Size under 128 samples. PCM doesn't incur those latency penalties, but uses more bandwidth."));
 
     mOptionsAutosizeStaticLabel = std::make_unique<Label>("", TRANS("Default Jitter Buffer"));
     configLabel(mOptionsAutosizeStaticLabel.get(), false);


### PR DESCRIPTION
Tooltip explaining the latency tradeoff between Opus and PCM:

![Screenshot at 2021-03-04 23-52-40](https://user-images.githubusercontent.com/6502474/110069898-d6ceec80-7d46-11eb-86fa-6cb783dea42e.png)

This is explained in the docs and videos, but this tooltip will help users when hovering over the Default Send Quality combobox.