### PR TITLE
AudioCodecFormatInfo:computeName consistent format

### DIFF
--- a/Source/SonobusPluginProcessor.cpp
+++ b/Source/SonobusPluginProcessor.cpp
@@ -1094,20 +1094,20 @@ String SonobusAudioProcessor::getCurrentJoinedGroup() const {
 void SonobusAudioProcessor::AudioCodecFormatInfo::computeName()
 {
     if (codec == SonobusAudioProcessor::CodecOpus) {
-        name = String::formatted("%d kbps/ch", bitrate/1000);
+        name = String::formatted("Opus %d kbps/ch", bitrate/1000);
     }
     else {
         if (bitdepth == 2) {
-            name = "PCM 16 bit";
+            name = "PCM 16 bit/ch";
         }
         else if (bitdepth == 3) {
-            name = "PCM 24 bit";
+            name = "PCM 24 bit/ch";
         }
         else if (bitdepth == 4) {
-            name = "PCM 32 bit float";
+            name = "PCM 32 bit/ch float";
         }
         else if (bitdepth == 8) {
-            name = "PCM 64 bit float";
+            name = "PCM 64 bit/ch float";
         }
     }
 }


### PR DESCRIPTION
I'm sorry if this is a bit trivial, but this more consistent string format reads better:

![image](https://user-images.githubusercontent.com/6502474/110071114-768d7a00-7d49-11eb-8d91-7433653af6d2.png)