### PR TITLE
Set minimum size 400x300 & very large max

### DIFF
--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -1162,7 +1162,7 @@ SonobusAudioProcessorEditor::SonobusAudioProcessorEditor (SonobusAudioProcessor&
 
     //updateServerFieldsFromConnectionInfo();
     
-    //setResizeLimits(400, 300, 2000, 1000);
+    setResizeLimits(400, 300, 10000, 10000);
 
     commandManager.registerAllCommandsForTarget (this);
 


### PR DESCRIPTION
Not clear to me why you wouldn't want a minimum size.  Without the minimum size, the plugin can be unintentionally very small to be unusuable:

![image](https://user-images.githubusercontent.com/6502474/110249882-73131200-7f46-11eb-9f4d-06801c139166.png)

but after forcing the minimum size to 400x300 here is what it looks like at the minimum size in Carla host: 

![image](https://user-images.githubusercontent.com/6502474/110249850-465efa80-7f46-11eb-8dee-2db526fe8d62.png)

(and I've bumped up the maximum size to be very large so hypothetically would work on >8k monitor)

If user really doesn't want to see the plugin, they can always minimize it, I think.