### PR TITLE
don't force rebuild local in on peer change state

### DIFF
--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -3553,8 +3553,7 @@ void SonobusAudioProcessorEditor::handleAsyncUpdate()
             //mPeerContainer->updateLayout();
             //mPeerContainer->resized();
             //Timer::callAfterDelay(100, [this](){
-            updatePeerState(true);
-            updateState();
+            updatePeerState(false);
             //});
         }
         else if (ev.type == ClientEvent::ConnectEvent) {


### PR DESCRIPTION
aooClientPeerChangeState asynchronous updates shouldn't cause local user who is editing input group names to lose their edits, so shouldn't rebuild input channel groups during the update.