### PR TITLE
Don't rebuild local input channels on peer updates

### DIFF
--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -1422,7 +1422,7 @@ bool SonobusAudioProcessorEditor::requestedQuit()
 
 void SonobusAudioProcessorEditor::connectionsChanged(ConnectView *comp)
 {
-    updateState();
+    updateState(false);
 }
 
 void SonobusAudioProcessorEditor::channelLayoutChanged(ChannelGroupsView *comp)
@@ -1702,7 +1702,7 @@ bool SonobusAudioProcessorEditor::updatePeerState(bool force)
             mPatchMatrixView->updateGrid();
         }
 
-        updateState();
+        updateState(false);
         return true;
     }
     else {
@@ -3322,7 +3322,7 @@ void SonobusAudioProcessorEditor::showMonitorDelayView(bool flag)
 }
 
 
-void SonobusAudioProcessorEditor::updateState()
+void SonobusAudioProcessorEditor::updateState(bool rebuildInputChannels)
 {
 
     currConnected = processor.isConnectedToServer();
@@ -3369,8 +3369,9 @@ void SonobusAudioProcessorEditor::updateState()
         inputMeter->setFixedNumChannels(processor.getActiveSendChannelCount());
     }
 
-    mInputChannelsContainer->rebuildChannelViews();
-
+    if (rebuildInputChannels) {
+        mInputChannelsContainer->rebuildChannelViews();
+    }
     
     bool sendmute = processor.getValueTreeState().getParameter(SonobusAudioProcessor::paramMainSendMute)->getValue();
     if (!mMainPushToTalkButton->isMouseButtonDown() && !mPushToTalkKeyDown) {
@@ -3619,7 +3620,7 @@ void SonobusAudioProcessorEditor::handleAsyncUpdate()
             //mPeerContainer->resized();
             //Timer::callAfterDelay(100, [this](){
             updatePeerState(true);
-            updateState();
+            updateState(false);
             //});
         }
         else if (ev.type == ClientEvent::ConnectEvent) {
@@ -3733,12 +3734,12 @@ void SonobusAudioProcessorEditor::handleAsyncUpdate()
             // delay update
             Timer::callAfterDelay(200, [this] {
                 updatePeerState(true);
-                updateState();
+                updateState(false);
             });
         }
         else if (ev.type == ClientEvent::PeerLeaveEvent) {
             updatePeerState(true);
-            updateState();
+            updateState(false);
         }
         else if (ev.type == ClientEvent::PeerPendingJoinEvent) {
             mPeerContainer->peerPendingJoin(ev.group, ev.user);

--- a/Source/SonobusPluginEditor.h
+++ b/Source/SonobusPluginEditor.h
@@ -161,7 +161,7 @@ private:
 
     void updateLayout();
 
-    void updateState();
+    void updateState(bool rebuildInputChannels = true);
     
     void configKnobSlider(Slider *);
     //void configLabel(Label * lab, bool val);


### PR DESCRIPTION
Adds a default true parameter rebuildInputChannels for function:
`SonobusAudioProcessorEditor::updateState(bool rebuildInputChannels)`

So I've left updateState behavior to normally rebuild input channels.  Except for peer update events, I'm calling updateState(false) so that the local input channels aren't rebuilt.

This avoids a bug where local user would loose edits to their input channel names because the channel name label would get rebuilt (which would appear like loosing focus but interanlly what really happened is the texteditor gets killed when the input channels were rebuilt).  This bug would happen when another user triggered the following functions:

`SonobusAudioProcessorEditor::connectionsChanged()`
`SonobusAudioProcessorEditor::updatePeerState()`
`SonobusAudioProcessorEditor::handleAsyncUpdate()` for
  - `ClientEvent::PeerChangedState`
  - `ClientEvent::PeerJoinEvent`
  - `ClientEvent::PeerLeaveEvent`
  
I'm not too familiar with your code base so you can probably suggest a better fix, but I made this PR out cause it seems to fix the bug and work at least.