### PR TITLE
Redundant UDP packet transmission as a way to decrease packet loss

### DIFF
--- a/Source/OptionsView.cpp
+++ b/Source/OptionsView.cpp
@@ -63,6 +63,24 @@ void OptionsView::initializeLanguages()
 
 }
 
+void OptionsView::updatePacketRedundancySliderColour(int redundancy)
+{
+    switch (redundancy) {
+        case 1:
+        case 2:
+            mOptionsPacketRedundancySlider->setColour(Slider::trackColourId, Colour::fromFloatRGBA(0.1, 0.4, 0.6, 0.3));
+            break;
+        case 3:
+            mOptionsPacketRedundancySlider->setColour(Slider::trackColourId, Colour::fromFloatRGBA(1.0, 0.722, 0, 0.3));
+            break;
+        case 4:
+            mOptionsPacketRedundancySlider->setColour(Slider::trackColourId, Colour::fromFloatRGBA(1.0, 0.36, 0, 0.3));
+            break;
+        case 5:
+        default:
+            mOptionsPacketRedundancySlider->setColour(Slider::trackColourId, Colour::fromFloatRGBA(1.0, 0.0, 0, 0.3));
+    }
+}
 
 OptionsView::OptionsView(SonobusAudioProcessor& proc, std::function<AudioDeviceManager*()> getaudiodevicemanager)
 : Component(), getAudioDeviceManager(getaudiodevicemanager), processor(proc), smallLNF(14), sonoSliderLNF(13)
@@ -313,11 +331,39 @@ OptionsView::OptionsView(SonobusAudioProcessor& proc, std::function<AudioDeviceM
 
     mOptionsAutoDropThreshSlider->setTooltip(TRANS("This controls how sensitive the auto-jitter buffer adjustment is when there are audio dropouts. The jitter buffer size will be increased if there are any dropouts within the number of seconds specified here. When this value is smaller it will be less likely to increase the jitter buffer size automatically."));
 
-
     mOptionsAutoDropThreshLabel = std::make_unique<Label>("", autodropname);
     mOptionsAutoDropThreshLabel->setAccessible(false);
     configLabel(mOptionsAutoDropThreshLabel.get(), false);
     mOptionsAutoDropThreshLabel->setJustificationType(Justification::centredLeft);
+
+    auto packetredundancyname = TRANS("Packet redundancy");
+    mOptionsPacketRedundancySlider = std::make_unique<Slider>(Slider::LinearBar,  Slider::TextBoxRight);
+    mOptionsPacketRedundancySlider->setTitle(packetredundancyname);
+    mOptionsPacketRedundancySlider->setRange(1.0, 5.0, 1.0);
+    mOptionsPacketRedundancySlider->setSkewFactor(0.5);
+    mOptionsPacketRedundancySlider->setName("packetredundancy");
+    mOptionsPacketRedundancySlider->setTextValueSuffix(" " + TRANS("packets"));
+    mOptionsPacketRedundancySlider->setSliderSnapsToMousePosition(false);
+    mOptionsPacketRedundancySlider->setChangeNotificationOnlyOnRelease(true);
+    mOptionsPacketRedundancySlider->setDoubleClickReturnValue(true, 2.0);
+    mOptionsPacketRedundancySlider->setTextBoxIsEditable(false);
+    mOptionsPacketRedundancySlider->setScrollWheelEnabled(false);
+    mOptionsPacketRedundancySlider->setColour(Slider::trackColourId, Colour::fromFloatRGBA(0.1, 0.4, 0.6, 0.3));
+    mOptionsPacketRedundancySlider->setWantsKeyboardFocus(true);
+
+    mOptionsPacketRedundancySlider->onValueChange = [this]() {
+        int redundancy = jmax(1.0, mOptionsPacketRedundancySlider->getValue());
+        processor.setPacketRedundancy(redundancy);
+        updatePacketRedundancySliderColour(redundancy);
+    };
+
+    mOptionsPacketRedundancySlider->setTooltip(TRANS("This controls how many redundant packets will be sent. SonoBus uses UDP for fast transmission but it can be unreliable. Sending multiple redundant packets can help to decrease packet loss and as a consequence latency if enough bandwidth is available. Use this setting very carefully as it directly multiplies your uploads and the receivers download bandwidth requirement."));
+
+    mOptionsPacketRedundancyLabel = std::make_unique<Label>("", packetredundancyname);
+    mOptionsPacketRedundancyLabel->setAccessible(false);
+    configLabel(mOptionsPacketRedundancyLabel.get(), false);
+    mOptionsPacketRedundancyLabel->setJustificationType(Justification::centredLeft);
+
 
     mOptionsSavePluginDefaultButton = std::make_unique<TextButton>("saveopt");
     mOptionsSavePluginDefaultButton->setButtonText(TRANS("Save as default plugin options"));
@@ -360,6 +406,8 @@ OptionsView::OptionsView(SonobusAudioProcessor& proc, std::function<AudioDeviceM
     mOptionsComponent->addAndMakeVisible(mOptionsLanguageLabel.get());
     mOptionsComponent->addAndMakeVisible(mOptionsAutoDropThreshSlider.get());
     mOptionsComponent->addAndMakeVisible(mOptionsAutoDropThreshLabel.get());
+    mOptionsComponent->addAndMakeVisible(mOptionsPacketRedundancySlider.get());
+    mOptionsComponent->addAndMakeVisible(mOptionsPacketRedundancyLabel.get());
 
     if (!JUCEApplication::isStandaloneApp()) {
         mOptionsComponent->addAndMakeVisible(mOptionsSavePluginDefaultButton.get());
@@ -578,6 +626,10 @@ void OptionsView::updateState(bool ignorecheck)
 
     mOptionsAutoDropThreshSlider->setValue(1 / jmax(0.001f, processor.getAutoresizeBufferDropRateThreshold()), dontSendNotification);
 
+    int redundancy = jmax(1, processor.getPacketRedundancy());
+    mOptionsPacketRedundancySlider->setValue(redundancy, dontSendNotification);
+    updatePacketRedundancySliderColour(redundancy);
+
     int port = processor.getUseSpecificUdpPort();
     if (port > 0) {
         mOptionsUdpPortEditor->setText(String::formatted("%d", port), dontSendNotification);
@@ -730,6 +782,11 @@ void OptionsView::updateLayout()
     optionsUdpBox.items.add(FlexItem(minButtonWidth, minitemheight, *mOptionsUseSpecificUdpPortButton).withMargin(0).withFlex(1));
     optionsUdpBox.items.add(FlexItem(90, minitemheight, *mOptionsUdpPortEditor).withMargin(0).withFlex(0));
 
+    optionsPacketRedundancyBox.items.clear();
+    optionsPacketRedundancyBox.flexDirection = FlexBox::Direction::row;
+    optionsPacketRedundancyBox.items.add(FlexItem(42, 12));
+    optionsPacketRedundancyBox.items.add(FlexItem(100, minitemheight, *mOptionsPacketRedundancySlider).withMargin(0).withFlex(1));
+
     optionsDynResampleBox.items.clear();
     optionsDynResampleBox.flexDirection = FlexBox::Direction::row;
     optionsDynResampleBox.items.add(FlexItem(10, 12).withFlex(0));
@@ -807,6 +864,8 @@ void OptionsView::updateLayout()
     optionsBox.items.add(FlexItem(100, minpassheight, optionsSnapToMouseBox).withMargin(2).withFlex(0));
     optionsBox.items.add(FlexItem(100, minpassheight, optionsAutoReconnectBox).withMargin(2).withFlex(0));
     optionsBox.items.add(FlexItem(100, minitemheight, optionsUdpBox).withMargin(2).withFlex(0));
+    optionsBox.items.add(FlexItem(4, 3));
+    optionsBox.items.add(FlexItem(100, minitemheight, optionsPacketRedundancyBox).withMargin(2).withFlex(0));
     if (JUCEApplicationBase::isStandaloneApp()) {
         optionsBox.items.add(FlexItem(100, minpassheight, optionsOverrideSamplerateBox).withMargin(2).withFlex(0));
         if (mOptionsAllowBluetoothInput) {
@@ -935,7 +994,7 @@ void OptionsView::resized()  {
     mOptionsDefaultLevelSlider->setMouseDragSensitivity(jmax(128, mOptionsDefaultLevelSlider->getWidth()));
 
     mOptionsAutoDropThreshLabel->setBounds(mOptionsAutoDropThreshSlider->getBounds().removeFromLeft(mOptionsAutoDropThreshSlider->getWidth()*0.75));
-
+    mOptionsPacketRedundancyLabel->setBounds(mOptionsPacketRedundancySlider->getBounds().removeFromLeft(mOptionsPacketRedundancySlider->getWidth()*0.75));
 }
 
 void OptionsView::showAudioTab()

--- a/Source/OptionsView.h
+++ b/Source/OptionsView.h
@@ -82,6 +82,7 @@ public:
 protected:
 
     void initializeLanguages();
+    void updatePacketRedundancySliderColour(int redundancy);
 
     void configEditor(TextEditor *editor, bool passwd = false);
     void configLabel(Label *label, bool val=false);
@@ -146,6 +147,9 @@ protected:
     std::unique_ptr<Label> mOptionsAutoDropThreshLabel;
     std::unique_ptr<Slider> mOptionsAutoDropThreshSlider;
 
+    std::unique_ptr<Label> mOptionsPacketRedundancyLabel;
+    std::unique_ptr<Slider> mOptionsPacketRedundancySlider;
+
     std::unique_ptr<SonoChoiceButton> mOptionsLanguageChoice;
     std::unique_ptr<Label> mOptionsLanguageLabel;
 
@@ -183,6 +187,7 @@ protected:
     FlexBox optionsLanguageBox;
     FlexBox optionsAllowBluetoothBox;
     FlexBox optionsAutoDropThreshBox;
+    FlexBox optionsPacketRedundancyBox;
     FlexBox optionsPluginDefaultBox;
 
     FlexBox recOptionsBox;

--- a/Source/SonobusPluginProcessor.h
+++ b/Source/SonobusPluginProcessor.h
@@ -289,7 +289,10 @@ public:
     void stopAooServer();
     
     // client stuff
-    
+
+    void setPacketRedundancy(int);
+    int getPacketRedundancy();
+
     // if value is 0, the system will choose any available UDP port (default)
     void setUseSpecificUdpPort(int port);
     int getUseSpecificUdpPort() const { return mUseSpecificUdpPort; }
@@ -1003,6 +1006,7 @@ private:
     RangedAudioParameter * mDefaultAutoNetbufModeParam;
     RangedAudioParameter * mTempoParameter;
 
+    int mPacketRedundancy = 1;
     int mUseSpecificUdpPort = 0;
 
     bool mLinkMonitoringDelayTimes = true;


### PR DESCRIPTION
This feature adds an option to the user to enable packet redundancy and it uses the native feature of the aoo lib for packet redundancy. UDP packets can get lost or unordered on their way to their destination and redundant packets can decrease overall packet loss and the jitter-buffer size if enough bandwidth is available.

To avoid a mindless activation of this feature the user gets warned twice. Once in the tooltip and furthermore by a specific colored feedback if redundancy levels are set to higher than two.

![image](https://github.com/sonosaurus/sonobus/assets/81837461/f868af3c-8edd-4c51-a19f-b68ebe6fe403)
*A configured packet redundancy of 4 with colored feedback*