### PR TITLE
iOS-only: Use maximum output channel count for interface

### DIFF
--- a/Source/CrossPlatformUtils.h
+++ b/Source/CrossPlatformUtils.h
@@ -20,4 +20,6 @@ void *binaryDataToUrlBookmark(const void * data, size_t size);
 
 juce::URL generateUpdatedURL (juce::URL& urlToUse);
 
+int getMaximumOutputNumberOfChannels();
+bool setPreferredOutputNumberOfChannels(int count);
 #endif

--- a/Source/CrossPlatformUtilsIOS.mm
+++ b/Source/CrossPlatformUtilsIOS.mm
@@ -15,6 +15,8 @@
 
 
 
+#import <AVFoundation/AVFoundation.h>
+
 #import <UIKit/UIView.h>
 
 #include "../JuceLibraryCode/JuceHeader.h"
@@ -108,6 +110,18 @@ juce::URL generateUpdatedURL (juce::URL& urlToUse)
     return returl;
 }
 
+int getMaximumOutputNumberOfChannels()
+{
+    auto* session = [AVAudioSession sharedInstance];
+    return [session maximumOutputNumberOfChannels];
+}
+
+bool setPreferredOutputNumberOfChannels(int count)
+{
+    auto* session = [AVAudioSession sharedInstance];
+    NSError* error;
+    return [session setPreferredOutputNumberOfChannels:count error:&error];
+}
 
 
 #endif

--- a/Source/SonoStandaloneFilterApp.cpp
+++ b/Source/SonoStandaloneFilterApp.cpp
@@ -442,6 +442,9 @@ public:
             return;
         };
 
+#if JUCE_IOS
+        setPreferredOutputNumberOfChannels(getMaximumOutputNumberOfChannels());
+#endif
 
         if (!doHeadless) {
             mainWindow.reset (createWindow());

--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -21,6 +21,8 @@
 #include "LatencyMatchView.h"
 #include "SuggestNewGroupView.h"
 #include "SonoCallOutBox.h"
+#include "CrossPlatformUtils.h"
+
 #include <sstream>
 
 #if JUCE_ANDROID
@@ -1938,6 +1940,8 @@ void SonobusAudioProcessorEditor::timerCallback(int timerid)
         
 #if JUCE_IOS
         if (JUCEApplicationBase::isStandaloneApp()) {
+            getAudioDeviceManager()->addChangeListener(this);
+
             bool iaaconn = isInterAppAudioConnected();
             if (iaaconn != iaaConnected) {
                 iaaConnected = iaaconn;
@@ -5174,6 +5178,11 @@ void SonobusAudioProcessorEditor::changeListenerCallback (ChangeBroadcaster* sou
     } else if (source == &(processor.getTransportSource())) {
         updateTransportState();
     }
+#if JUCE_IOS
+    else if (source == getAudioDeviceManager()) {
+        setPreferredOutputNumberOfChannels(getMaximumOutputNumberOfChannels());
+    }
+#endif
 }
 
 class SonobusAudioProcessorEditor::TrimFileJob : public ThreadPoolJob


### PR DESCRIPTION
Allows using (cheap) 5.1 / 7.1 channel interfaces as a 6-channel / 8-channel interface instead of the default stereo behaviour for such interfaces on iOS.

Example product: https://www.amazon.ca/gp/product/B07QBZVNPW

Fulfills https://github.com/sonosaurus/sonobus/issues/137