### PR TITLE
iOS-only: Add input gain / "In Level" slider

### DIFF
--- a/Source/ChannelGroupsView.cpp
+++ b/Source/ChannelGroupsView.cpp
@@ -932,12 +932,6 @@ ChannelGroupsView::ChannelGroupsView(SonobusAudioProcessor& proc, bool peerMode,
     //bgColor = Colour::fromFloatRGBA(0.045f, 0.045f, 0.05f, 1.0f);
     bgColor = Colour::fromFloatRGBA(0.08f, 0.045f, 0.08f, 1.0f);
 
-    mInGainSlider     = std::make_unique<Slider>(Slider::LinearHorizontal,  Slider::TextBoxAbove);
-    mInGainSlider->setName("ingain");
-    mInGainSlider->setSliderSnapsToMousePosition(processor.getSlidersSnapToMousePosition());
-    mInGainSlider->setTextBoxIsEditable(true);
-    mInGainSlider->setScrollWheelEnabled(false);
-
     mAddButton = std::make_unique<TextButton>("+");
     mAddButton->setTitle(TRANS("Add Input Group"));
     mAddButton->onClick = [this] {  addGroupPressed(); };

--- a/Source/ChannelGroupsView.h
+++ b/Source/ChannelGroupsView.h
@@ -435,7 +435,6 @@ protected:
 
 
 
-    std::unique_ptr<Slider> mInGainSlider;
     std::unique_ptr<TextButton> mAddButton;
     std::unique_ptr<TextButton> mClearButton;
     std::unique_ptr<TextButton> mInReverbButton;

--- a/Source/CrossPlatformUtils.h
+++ b/Source/CrossPlatformUtils.h
@@ -20,4 +20,7 @@ void *binaryDataToUrlBookmark(const void * data, size_t size);
 
 juce::URL generateUpdatedURL (juce::URL& urlToUse);
 
+bool getIsInputGainSettable();
+float getInputGain();
+bool setInputGain(float gain);
 #endif

--- a/Source/CrossPlatformUtilsIOS.mm
+++ b/Source/CrossPlatformUtilsIOS.mm
@@ -15,6 +15,8 @@
 
 
 
+#import <AVFoundation/AVFoundation.h>
+
 #import <UIKit/UIView.h>
 
 #include "../JuceLibraryCode/JuceHeader.h"
@@ -109,5 +111,21 @@ juce::URL generateUpdatedURL (juce::URL& urlToUse)
 }
 
 
+bool getIsInputGainSettable()
+{
+    auto* session = [AVAudioSession sharedInstance];
+    return [session isInputGainSettable];
+}
+
+float getInputGain() {
+    auto* session = [AVAudioSession sharedInstance];
+    return [session inputGain];
+}
+
+bool setInputGain(float gain) {
+    auto* session = [AVAudioSession sharedInstance];
+    NSError* error;
+    return [session setInputGain:gain error:&error];
+}
 
 #endif

--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -673,7 +673,6 @@ SonobusAudioProcessorEditor::SonobusAudioProcessorEditor (SonobusAudioProcessor&
     smallerEditorFontsize = 16;
 #endif
     
-    mInGainAttachment     = std::make_unique<AudioProcessorValueTreeState::SliderAttachment> (p.getValueTreeState(), SonobusAudioProcessor::paramInGain, *mInGainSlider);
     mDryAttachment     = std::make_unique<AudioProcessorValueTreeState::SliderAttachment> (p.getValueTreeState(), SonobusAudioProcessor::paramDry, *mDrySlider);
     mWetAttachment     = std::make_unique<AudioProcessorValueTreeState::SliderAttachment> (p.getValueTreeState(), SonobusAudioProcessor::paramWet, *mOutGainSlider);
     mMainSendMuteAttachment = std::make_unique<AudioProcessorValueTreeState::ButtonAttachment> (p.getValueTreeState(), SonobusAudioProcessor::paramMainSendMute, *mMainMuteButton);
@@ -4659,13 +4658,12 @@ void SonobusAudioProcessorEditor::updateLayout()
     int inmixw = 74;
     int choicew = inmixw + mutew + 3;
 
-    inGainBox.items.clear();
-    inGainBox.flexDirection = FlexBox::Direction::row;
-    //inGainBox.items.add(FlexItem(minKnobWidth, minitemheight, *mInGainSlider).withMargin(0).withFlex(1));
-    //inGainBox.items.add(FlexItem(choicew, minitemheight, *mSendChannelsLabel).withMargin(0).withFlex(0.5));
-    inGainBox.items.add(FlexItem(2, 6).withMargin(0).withFlex(0.1));
-    inGainBox.items.add(FlexItem(choicew, minitemheight, *mSendChannelsChoice).withMargin(0).withFlex(1).withMaxWidth(160));
-    inGainBox.items.add(FlexItem(2, 6).withMargin(0).withFlex(0.1));
+    sendChannelsBox.items.clear();
+    sendChannelsBox.flexDirection = FlexBox::Direction::row;
+    //sendChannelsBox.items.add(FlexItem(choicew, minitemheight, *mSendChannelsLabel).withMargin(0).withFlex(0.5));
+    sendChannelsBox.items.add(FlexItem(2, 6).withMargin(0).withFlex(0.1));
+    sendChannelsBox.items.add(FlexItem(choicew, minitemheight, *mSendChannelsChoice).withMargin(0).withFlex(1).withMaxWidth(160));
+    sendChannelsBox.items.add(FlexItem(2, 6).withMargin(0).withFlex(0.1));
 
     dryBox.items.clear();
     dryBox.flexDirection = FlexBox::Direction::row;
@@ -4696,7 +4694,7 @@ void SonobusAudioProcessorEditor::updateLayout()
 
     inputLeftBox.items.clear();
     inputLeftBox.flexDirection = FlexBox::Direction::column;
-    inputLeftBox.items.add(FlexItem(choicew + 4, minitemheight, inGainBox).withMargin(0).withFlex(1)); //.withMaxWidth(isNarrow ? 160 : 120));
+    inputLeftBox.items.add(FlexItem(choicew + 4, minitemheight, sendChannelsBox).withMargin(0).withFlex(1)); //.withMaxWidth(isNarrow ? 160 : 120));
     inputLeftBox.items.add(FlexItem(4, 4).withMargin(0).withFlex(0));
     inputLeftBox.items.add(FlexItem(mutew+inmixw + 10, minitemheight, inputPannerBox).withMargin(0).withFlex(1)); //.withMaxWidth(maxPannerWidth));
 

--- a/Source/SonobusPluginEditor.h
+++ b/Source/SonobusPluginEditor.h
@@ -626,7 +626,7 @@ private:
     FlexBox remoteSourceBox;
     FlexBox remoteSinkBox;
     FlexBox paramsBox;
-    FlexBox inGainBox;
+    FlexBox sendChannelsBox;
     FlexBox dryBox;
     FlexBox wetBox;
     FlexBox toolbarBox;
@@ -697,7 +697,6 @@ private:
     
     std::unique_ptr<CustomTooltipWindow> tooltipWindow;
     
-    std::unique_ptr<AudioProcessorValueTreeState::SliderAttachment> mInGainAttachment;
     std::unique_ptr<AudioProcessorValueTreeState::SliderAttachment> mDryAttachment;
     std::unique_ptr<AudioProcessorValueTreeState::SliderAttachment> mWetAttachment;
     std::unique_ptr<AudioProcessorValueTreeState::ButtonAttachment> mMainSendMuteAttachment;

--- a/Source/SonobusPluginEditor.h
+++ b/Source/SonobusPluginEditor.h
@@ -298,7 +298,9 @@ private:
     std::unique_ptr<SonoDrawableButton> mMainLinkButton;
     std::unique_ptr<Drawable> mMainLinkArrow;
 
+#if JUCE_IOS
     std::unique_ptr<Slider> mInGainSlider;
+#endif
 
     std::unique_ptr<TextButton> mInMixerButton;
 
@@ -332,7 +334,9 @@ private:
     std::unique_ptr<DrawableRectangle> mFileAreaBg;
 
 
+#if JUCE_IOS
     std::unique_ptr<Label> mInGainLabel;
+#endif
     std::unique_ptr<Label> mDryLabel;
     std::unique_ptr<Label> mWetLabel;
     std::unique_ptr<Label> mOutGainLabel;
@@ -530,6 +534,10 @@ private:
     std::unique_ptr<Viewport> mMainViewport;
     std::unique_ptr<Component> mMainContainer;
     std::unique_ptr<PeersContainerView> mPeerContainer;
+
+#if JUCE_IOS
+    std::unique_ptr<Component> mInGainContainer;
+#endif
 
     std::unique_ptr<Viewport> mInputChannelsViewport;
     std::unique_ptr<ChannelGroupsView> mInputChannelsContainer;

--- a/Source/SonobusPluginProcessor.cpp
+++ b/Source/SonobusPluginProcessor.cpp
@@ -41,7 +41,6 @@ typedef int socklen_t;
 #define SENDBUFSIZE_SCALAR 2.0f
 #define PEER_PING_INTERVAL_MS 2000.0
 
-String SonobusAudioProcessor::paramInGain     ("ingain");
 String SonobusAudioProcessor::paramDry     ("dry");
 String SonobusAudioProcessor::paramInMonitorMonoPan     ("inmonmonopan");
 String SonobusAudioProcessor::paramInMonitorPan1     ("inmonpan1");
@@ -602,10 +601,6 @@ soundboardChannelProcessor(std::make_unique<SoundboardChannelProcessor>()),
 mGlobalState("SonobusGlobalState"),
 mState (*this, &mUndoManager, "SonoBusAoO",
 {
-           std::make_unique<AudioParameterFloat>(ParameterID(paramInGain, 1),     TRANS ("In Gain"),    NormalisableRange<float>(0.0, 4.0, 0.0, 0.33), mInGain.get(), "", AudioProcessorParameter::genericParameter,
-                                          [](float v, int maxlen) -> String { return Decibels::toString(Decibels::gainToDecibels(v), 1); }, 
-                                          [](const String& s) -> float { return Decibels::decibelsToGain(s.getFloatValue()); }),
-
     std::make_unique<AudioParameterFloat>(ParameterID(paramInMonitorMonoPan, 1),     TRANS ("In Pan"),    NormalisableRange<float>(-1.0, 1.0, 0.0), mInMonMonoPan.get(), "", AudioProcessorParameter::genericParameter,
                                           [](float v, int maxlen) -> String { if (fabs(v) < 0.01) return TRANS("C"); return String((int)rint(abs(v*100.0f))) + ((v > 0 ? "% R" : "% L")) ; },
                                           [](const String& s) -> float { return s.getFloatValue()*1e-2f; }),
@@ -691,7 +686,6 @@ mState (*this, &mUndoManager, "SonoBusAoO",
 
 })
 {
-    mState.addParameterListener (paramInGain, this);
     mState.addParameterListener (paramDry, this);
     mState.addParameterListener (paramWet, this);
     mState.addParameterListener (paramInMonitorMonoPan, this);
@@ -6566,12 +6560,6 @@ void SonobusAudioProcessor::parameterChanged (const String &parameterID, float n
 {
     if (parameterID == paramDry) {
         mDry = newValue;
-    }
-    else if (parameterID == paramInGain) {
-        //mInGain = newValue; // NO LONGER USE GLOBAL mInGain
-
-        // for now just apply it to the first input channel group
-        //mInputChannelGroups[0].gain = newValue;
     }
     else if (parameterID == paramMetGain) {
         mMetGain = newValue;

--- a/Source/SonobusPluginProcessor.h
+++ b/Source/SonobusPluginProcessor.h
@@ -235,7 +235,6 @@ public:
     
     AudioProcessorValueTreeState& getValueTreeState();
 
-    static String paramInGain;
     static String paramInMonitorMonoPan;
     static String paramInMonitorPan1;
     static String paramInMonitorPan2;


### PR DESCRIPTION
For audio interfaces which support it **on iOS**, adds a single interface-wide slider "In Level" (i.e. applies to all input channels) to the Input Mixer.

This allows reducing the audio gain -- potentially at the hardware level, if that is how the audio interface implements it -- which can avoid clipping if a hot signal is present.

Fulfills https://github.com/sonosaurus/sonobus/issues/216