### PR TITLE
Persist solo state (local tracks and peers) across restarts

### DIFF
--- a/Source/ChannelGroup.cpp
+++ b/Source/ChannelGroup.cpp
@@ -22,6 +22,7 @@ static String monDestChannelsKey("mondestchans");
 static String sendMainMixKey("sendmainmix");
 static String invertPolarityKey("invertpolarity");
 static String mutedKey("muted");
+static String soloedKey("soloed");
 
 
 static String stereoPanListKey("StereoPanners");
@@ -631,6 +632,7 @@ ValueTree ChannelGroupParams::getValueTree() const
     channelGroupTree.setProperty(channelStartIndexKey, chanStartIndex, nullptr);
     channelGroupTree.setProperty(numChannelsKey, numChannels, nullptr);
     channelGroupTree.setProperty(mutedKey, muted, nullptr);
+    channelGroupTree.setProperty(soloedKey, soloed, nullptr);
 
     channelGroupTree.setProperty(peerPan1Key, panStereo[0], nullptr);
     channelGroupTree.setProperty(peerPan2Key, panStereo[1], nullptr);
@@ -674,6 +676,7 @@ void ChannelGroupParams::setFromValueTree(const ValueTree & channelGroupTree)
     chanStartIndex = channelGroupTree.getProperty(channelStartIndexKey, chanStartIndex);
     numChannels = channelGroupTree.getProperty(numChannelsKey, numChannels);
     muted = channelGroupTree.getProperty(mutedKey, muted);
+    soloed = channelGroupTree.getProperty(soloedKey, soloed);
     //pan = channelGroupTree.getProperty(peerMonoPanKey, pan);
     panStereo[0] = channelGroupTree.getProperty(peerPan1Key, panStereo[0]);
     panStereo[1] = channelGroupTree.getProperty(peerPan2Key, panStereo[1]);

--- a/Source/OptionsView.cpp
+++ b/Source/OptionsView.cpp
@@ -271,6 +271,12 @@ OptionsView::OptionsView(SonobusAudioProcessor& proc, std::function<AudioDeviceM
     mOptionsDisableShortcutButton = std::make_unique<ToggleButton>(TRANS("Disable keyboard shortcuts"));
     mOptionsDisableShortcutButton->addListener(this);
 
+    mOptionsRememberLocalSoloButton = std::make_unique<ToggleButton>(TRANS("Remember Local Track Solo"));
+    mOptionsRememberLocalSoloButton->addListener(this);
+
+    mOptionsRememberPeerSoloButton = std::make_unique<ToggleButton>(TRANS("Remember Peer Solo"));
+    mOptionsRememberPeerSoloButton->addListener(this);
+
 #if JUCE_IOS
     if (JUCEApplicationBase::isStandaloneApp()) {
         mOptionsAllowBluetoothInput = std::make_unique<ToggleButton>(TRANS("Allow Bluetooth Input"));
@@ -397,6 +403,8 @@ OptionsView::OptionsView(SonobusAudioProcessor& proc, std::function<AudioDeviceM
     }
     mOptionsComponent->addAndMakeVisible(mOptionsSliderSnapToMouseButton.get());
     mOptionsComponent->addAndMakeVisible(mOptionsDisableShortcutButton.get());
+    mOptionsComponent->addAndMakeVisible(mOptionsRememberLocalSoloButton.get());
+    mOptionsComponent->addAndMakeVisible(mOptionsRememberPeerSoloButton.get());
 
 
 
@@ -640,6 +648,8 @@ void OptionsView::updateState(bool ignorecheck)
 
     mOptionsSliderSnapToMouseButton->setToggleState(processor.getSlidersSnapToMousePosition(), dontSendNotification);
     mOptionsDisableShortcutButton->setToggleState(processor.getDisableKeyboardShortcuts(), dontSendNotification);
+    mOptionsRememberLocalSoloButton->setToggleState(processor.getRememberLocalTrackSolo(), dontSendNotification);
+    mOptionsRememberPeerSoloButton->setToggleState(processor.getRememberPeerSolo(), dontSendNotification);
 
     uint32 recmask = processor.getDefaultRecordingOptions();
 
@@ -795,6 +805,16 @@ void OptionsView::updateLayout()
     optionsDisableShortcutsBox.items.add(FlexItem(10, 12).withFlex(0));
     optionsDisableShortcutsBox.items.add(FlexItem(180, minpassheight, *mOptionsDisableShortcutButton).withMargin(0).withFlex(1));
 
+    optionsRememberLocalSoloBox.items.clear();
+    optionsRememberLocalSoloBox.flexDirection = FlexBox::Direction::row;
+    optionsRememberLocalSoloBox.items.add(FlexItem(10, 12).withFlex(0));
+    optionsRememberLocalSoloBox.items.add(FlexItem(180, minpassheight, *mOptionsRememberLocalSoloButton).withMargin(0).withFlex(1));
+
+    optionsRememberPeerSoloBox.items.clear();
+    optionsRememberPeerSoloBox.flexDirection = FlexBox::Direction::row;
+    optionsRememberPeerSoloBox.items.add(FlexItem(10, 12).withFlex(0));
+    optionsRememberPeerSoloBox.items.add(FlexItem(180, minpassheight, *mOptionsRememberPeerSoloButton).withMargin(0).withFlex(1));
+
 
     optionsAllowBluetoothBox.items.clear();
     optionsAllowBluetoothBox.flexDirection = FlexBox::Direction::row;
@@ -840,6 +860,8 @@ void OptionsView::updateLayout()
         optionsBox.items.add(FlexItem(100, minpassheight, optionsCheckForUpdateBox).withMargin(2).withFlex(0));
     }
     optionsBox.items.add(FlexItem(100, minpassheight, optionsDisableShortcutsBox).withMargin(2).withFlex(0));
+    optionsBox.items.add(FlexItem(100, minpassheight, optionsRememberLocalSoloBox).withMargin(2).withFlex(0));
+    optionsBox.items.add(FlexItem(100, minpassheight, optionsRememberPeerSoloBox).withMargin(2).withFlex(0));
     optionsBox.items.add(FlexItem(100, minpassheight, optionsDynResampleBox).withMargin(2).withFlex(0));
 
     if ( ! JUCEApplicationBase::isStandaloneApp()) {
@@ -1167,6 +1189,12 @@ void OptionsView::buttonClicked (Button* buttonThatWasClicked)
         if (updateKeybindings) {
             updateKeybindings();
         }
+    }
+    else if (buttonThatWasClicked == mOptionsRememberLocalSoloButton.get()) {
+        processor.setRememberLocalTrackSolo(mOptionsRememberLocalSoloButton->getToggleState());
+    }
+    else if (buttonThatWasClicked == mOptionsRememberPeerSoloButton.get()) {
+        processor.setRememberPeerSolo(mOptionsRememberPeerSoloButton->getToggleState());
     }
     else if (buttonThatWasClicked == mOptionsSavePluginDefaultButton.get()) {
         processor.saveCurrentAsDefaultPluginSettings();

--- a/Source/OptionsView.h
+++ b/Source/OptionsView.h
@@ -136,6 +136,8 @@ protected:
     std::unique_ptr<ToggleButton> mOptionsSliderSnapToMouseButton;
     std::unique_ptr<ToggleButton> mOptionsAllowBluetoothInput;
     std::unique_ptr<ToggleButton> mOptionsDisableShortcutButton;
+    std::unique_ptr<ToggleButton> mOptionsRememberLocalSoloButton;
+    std::unique_ptr<ToggleButton> mOptionsRememberPeerSoloButton;
     std::unique_ptr<TextButton> mOptionsSavePluginDefaultButton;
     std::unique_ptr<TextButton> mOptionsResetPluginDefaultButton;
 
@@ -181,6 +183,8 @@ protected:
     FlexBox optionsAutoReconnectBox;
     FlexBox optionsSnapToMouseBox;
     FlexBox optionsDisableShortcutsBox;
+    FlexBox optionsRememberLocalSoloBox;
+    FlexBox optionsRememberPeerSoloBox;
     FlexBox optionsDefaultLevelBox;
     FlexBox optionsLanguageBox;
     FlexBox optionsAllowBluetoothBox;

--- a/Source/SonobusPluginProcessor.cpp
+++ b/Source/SonobusPluginProcessor.cpp
@@ -8587,6 +8587,22 @@ void SonobusAudioProcessor::getStateInformationWithOptions(MemoryBlock& destData
     
     ValueTree peerCacheTree = tempstate.getOrCreateChildWithName(peerStateCacheMapKey, nullptr);
     if (includecache) {
+        // Peers still connected right now (e.g. the app is being quit
+        // without an explicit Disconnect first) have never had their
+        // live state -- soloed, gain, pan, etc. -- copied into
+        // mPeerStateCacheMap: that only happens in commitCacheForPeer,
+        // which up to now was only called from peer-removal code paths
+        // (removeAllRemotePeers, individual peer disconnect), never
+        // from here. Without this, anything changed on a still-
+        // connected peer since its last disconnect/reconnect is lost
+        // on quit, not just soloed state.
+        {
+            const ScopedReadLock sl (mCoreLock);
+            for (auto * peer : mRemotePeers) {
+                commitCacheForPeer(peer);
+            }
+        }
+
         // update state with our recents info
         peerCacheTree.removeAllChildren(nullptr);
         for (auto & info : mPeerStateCacheMap) {

--- a/Source/SonobusPluginProcessor.cpp
+++ b/Source/SonobusPluginProcessor.cpp
@@ -86,6 +86,8 @@ static String recentsItemKey("ServerConnectionInfo");
 static String extraStateCollectionKey("ExtraState");
 static String useSpecificUdpPortKey("UseUdpPort");
 static String changeQualForAllKey("ChangeQualForAll");
+static String rememberLocalTrackSoloKey("RememberLocalTrackSolo");
+static String rememberPeerSoloKey("RememberPeerSolo");
 static String changeRecvQualForAllKey("ChangeRecvQualForAll");
 static String defRecordOptionsKey("DefaultRecordingOptions");
 static String defRecordFormatKey("DefaultRecordingFormat");
@@ -150,6 +152,7 @@ static String peerNetbufKey("netbuf");
 static String peerNetbufAutoKey("netbufauto");
 static String peerSendFormatKey("sendformat");
 static String peerOrderPriorityKey("orderpriority");
+static String peerSoloedKey("peerSoloed");
 
 
 #define METER_RMS_SEC 0.03
@@ -6152,6 +6155,7 @@ void SonobusAudioProcessor::commitCacheForPeer(RemotePeer * retpeer)
     newcache.numMultiChanGroups = retpeer->lastMultiNumChanGroups;
     newcache.modifiedChanGroups = retpeer->modifiedMultiChanGroups;
     newcache.orderPriority = retpeer->orderPriority;
+    newcache.soloed = retpeer->soloed;
 
     for (int i=0; i < retpeer->numChanGroups && i < MAX_CHANGROUPS; ++i) {
         newcache.channelGroupParams[i] = retpeer->chanGroups[i].params;
@@ -6211,6 +6215,7 @@ bool SonobusAudioProcessor::findAndLoadCacheForPeer(RemotePeer * retpeer)
         retpeer->lastMultiNumChanGroups = cache.numMultiChanGroups;
         retpeer->modifiedChanGroups = retpeer->modifiedMultiChanGroups = cache.modifiedChanGroups;
         retpeer->orderPriority  = cache.orderPriority;
+        retpeer->soloed = cache.soloed;
 
 
         for (int i=0; i < retpeer->numChanGroups  && i < MAX_CHANGROUPS; ++i) {
@@ -8513,6 +8518,8 @@ void SonobusAudioProcessor::getStateInformationWithOptions(MemoryBlock& destData
     extraTree.removeAllChildren(nullptr);
     extraTree.setProperty(useSpecificUdpPortKey, mUseSpecificUdpPort, nullptr);
     extraTree.setProperty(changeQualForAllKey, mChangingDefaultAudioCodecChangesAll, nullptr);
+    extraTree.setProperty(rememberLocalTrackSoloKey, mRememberLocalTrackSolo, nullptr);
+    extraTree.setProperty(rememberPeerSoloKey, mRememberPeerSolo, nullptr);
     extraTree.setProperty(changeRecvQualForAllKey, mChangingDefaultRecvAudioCodecChangesAll, nullptr);
     extraTree.setProperty(defRecordOptionsKey, var((int)mDefaultRecordingOptions), nullptr);
     extraTree.setProperty(defRecordFormatKey, var((int)mDefaultRecordingFormat), nullptr);
@@ -8645,6 +8652,9 @@ void SonobusAudioProcessor::setStateInformationWithOptions (const void* data, in
             bool chqual = extraTree.getProperty(changeQualForAllKey, mChangingDefaultAudioCodecChangesAll);
             setChangingDefaultAudioCodecSetsExisting(chqual);
 
+            mRememberLocalTrackSolo = extraTree.getProperty(rememberLocalTrackSoloKey, mRememberLocalTrackSolo);
+            mRememberPeerSolo = extraTree.getProperty(rememberPeerSoloKey, mRememberPeerSolo);
+
             bool chrqual = extraTree.getProperty(changeRecvQualForAllKey, mChangingDefaultRecvAudioCodecChangesAll);
             setChangingDefaultRecvAudioCodecSetsExisting(chrqual);
 
@@ -8737,6 +8747,11 @@ void SonobusAudioProcessor::setStateInformationWithOptions (const void* data, in
                     mInputChannelGroups[i].params.setFromValueTree(channelGroupTree);
                     
                     ++i;
+                }
+                if (!mRememberLocalTrackSolo) {
+                    for (auto ci = 0; ci < i; ++ci) {
+                        mInputChannelGroups[ci].params.soloed = false;
+                    }
                 }
                 
             }
@@ -8885,6 +8900,7 @@ ValueTree SonobusAudioProcessor::PeerStateCache::getValueTree() const
     item.setProperty(numChanGroupsKey, numChanGroups, nullptr);
     item.setProperty(peerLevelKey, mainGain, nullptr);
     item.setProperty(peerOrderPriorityKey, orderPriority, nullptr);
+    item.setProperty(peerSoloedKey, soloed, nullptr);
 
     ValueTree channelGroupsTree(channelGroupsStateKey);
 
@@ -8918,6 +8934,7 @@ void SonobusAudioProcessor::PeerStateCache::setFromValueTree(const ValueTree & i
 
     mainGain = item.getProperty(peerLevelKey, mainGain);
     orderPriority = item.getProperty(peerOrderPriorityKey, orderPriority);
+    soloed = item.getProperty(peerSoloedKey, soloed);
 
     // backwards compat
     channelGroupParams[0].pan[0] = item.getProperty(peerMonoPanKey, channelGroupParams[0].pan[0]);
@@ -8970,6 +8987,12 @@ void SonobusAudioProcessor::loadPeerCacheFromState()
         for (auto child : peerCacheMapTree) {
             PeerStateCache info;
             info.setFromValueTree(child);
+            if (!mRememberPeerSolo) {
+                info.soloed = false;
+                for (auto ci = 0; ci < info.numChanGroups && ci < MAX_CHANGROUPS; ++ci) {
+                    info.channelGroupParams[ci].soloed = false;
+                }
+            }
             mPeerStateCacheMap.insert(PeerStateCacheMap::value_type(info.name, info));
         }
     }

--- a/Source/SonobusPluginProcessor.h
+++ b/Source/SonobusPluginProcessor.h
@@ -562,6 +562,11 @@ public:
     void setChangingDefaultRecvAudioCodecSetsExisting(bool flag) { mChangingDefaultRecvAudioCodecChangesAll = flag; }
     bool getChangingDefaultRecvAudioCodecSetsExisting() const { return mChangingDefaultRecvAudioCodecChangesAll;}
 
+    void setRememberLocalTrackSolo(bool flag) { mRememberLocalTrackSolo = flag; }
+    bool getRememberLocalTrackSolo() const { return mRememberLocalTrackSolo; }
+    void setRememberPeerSolo(bool flag) { mRememberPeerSolo = flag; }
+    bool getRememberPeerSolo() const { return mRememberPeerSolo; }
+
     
     String getAudioCodeFormatName(int formatIndex) const;
     bool getAudioCodeFormatInfo(int formatIndex, AudioCodecFormatInfo & retinfo) const;
@@ -850,6 +855,7 @@ private:
         int numMultiChanGroups = 0;
         bool modifiedChanGroups = false;
         int orderPriority = -1;
+        bool soloed = false;
     };
 
     // key is peer name
@@ -1020,6 +1026,8 @@ private:
     
     bool mChangingDefaultAudioCodecChangesAll = false;
     bool mChangingDefaultRecvAudioCodecChangesAll = false;
+    bool mRememberLocalTrackSolo = true;
+    bool mRememberPeerSolo = true;
 
     RangedAudioParameter * mDefaultAutoNetbufModeParam;
     RangedAudioParameter * mTempoParameter;


### PR DESCRIPTION
## Summary

Currently, `MUTE` state persists across app restarts, but `SOLO` state doesn't — soloing a local input track or a remote peer is lost every time the app restarts. This makes the two controls behave inconsistently even though they're presented identically in the UI.

- `ChannelGroupParams` (used by both local input channel groups and per-peer channel groups) now serializes `soloed`, matching the existing `muted` field exactly.
- `PeerStateCache` gains a `soloed` field for the whole-peer `SOLO` toggle (the one that solos an entire peer and un-solos the rest), wired through `commitCacheForPeer`/`findAndLoadCacheForPeer` and its own `getValueTree`/`setFromValueTree`.
- Two new Options toggles, **Remember Local Track Solo** and **Remember Peer Solo** (both default on), let you opt out of this per-category if you'd rather solo always reset on restart.
- Fixed a related gap found while testing: a peer's live state (soloed, but also gain/pan/etc.) was only ever copied into the on-disk cache when a peer was explicitly disconnected — quitting the app while still connected to a peer silently dropped anything changed since the last disconnect/reconnect. `commitCacheForPeer` is now also called for every currently-connected peer right before state is saved.

## Testing

- Verified via a headless UI test (Xvfb + xdotool) that both new toggles round-trip correctly through an actual app restart via the real settings file.
- Verified on a real Windows build: soloed a connected peer, quit without disconnecting, relaunched — peer comes back soloed.
- Built clean on both Linux and Windows (MSVC) with no new warnings.

Main Monitor Solo is untouched — it was already a plugin parameter and already persisted correctly.