### PR TITLE
Retry original username before falling back to an auto-incremented name

### DIFF
--- a/Source/SonobusPluginEditor.cpp
+++ b/Source/SonobusPluginEditor.cpp
@@ -3880,37 +3880,94 @@ void SonobusAudioProcessorEditor::handleAsyncUpdate()
         }
         else if (ev.type == ClientEvent::ConnectEvent) {
             String statstr;
+            // Captured once, up front, on any successful outcome -- the
+            // in-progress retry base name (if any) needs to survive
+            // just long enough to be used for the recents entry below,
+            // but retry state itself must not leak into whatever
+            // connect attempt comes next, regardless of which success
+            // sub-branch runs.
+            String retriedFromBaseUsername;
             if (ev.success) {
-                statstr = TRANS("Connected to server");                
+                statstr = TRANS("Connected to server");
+                retriedFromBaseUsername = mConnectRetryBaseUsername;
+                mConnectRetryBaseUsername.clear();
+                mConnectRetryCount = 0;
             } else {
                 if (String(ev.message).contains("access denied")) {
-                    statstr = TRANS("Already connected with this user name");
 
-                    // try again with different username (auto-incremented)
-                    currConnectionInfo.userName = generateNewUsername(currConnectionInfo);
+                    // First rejection for this connect attempt: remember
+                    // the name the user actually asked for, before we
+                    // touch currConnectionInfo.userName at all.
+                    if (mConnectRetryBaseUsername.isEmpty()) {
+                        mConnectRetryBaseUsername = currConnectionInfo.userName;
+                    }
 
-                    DBG("Trying again with name: " << currConnectionInfo.userName);
-                    connectWithInfo(currConnectionInfo, true);
-                    
-                    return;
-                    
+                    if (mConnectRetryCount < mConnectRetryMaxAttempts) {
+                        // Could be our own stale session from a recent
+                        // drop/restart, not yet timed out server-side --
+                        // retry the ORIGINAL name a few times before
+                        // assuming it's genuinely taken by someone else.
+                        ++mConnectRetryCount;
+                        statstr = TRANS("Already connected with this user name, retrying...");
+
+                        DBG("Access denied, retry " << mConnectRetryCount << "/" << mConnectRetryMaxAttempts << " with original name: " << mConnectRetryBaseUsername);
+
+                        Timer::callAfterDelay(mConnectRetryDelayMs, [this]() {
+                            currConnectionInfo.userName = mConnectRetryBaseUsername;
+                            connectWithInfo(currConnectionInfo, true);
+                        });
+
+                        return;
+                    }
+                    else {
+                        statstr = TRANS("Already connected with this user name");
+
+                        // Retries exhausted -- fall back to an
+                        // auto-incremented name, built from the
+                        // original base name (not whatever
+                        // currConnectionInfo.userName currently holds).
+                        AooServerConnectionInfo basedinfo = currConnectionInfo;
+                        basedinfo.userName = mConnectRetryBaseUsername;
+                        currConnectionInfo.userName = generateNewUsername(basedinfo);
+
+                        DBG("Retries exhausted, trying again with name: " << currConnectionInfo.userName);
+                        connectWithInfo(currConnectionInfo, true);
+
+                        return;
+                    }
+
                 } else {
                     statstr = TRANS("Connect failed: ") + ev.message;
+                    // definitive non-retriable failure -- reset retry state
+                    mConnectRetryBaseUsername.clear();
+                    mConnectRetryCount = 0;
                 }
 
             }
-            
+
             // we might already have autojoined a group, only attempt if we haven't
             if (processor.getCurrentJoinedGroup().isEmpty()) {
-                
+
                 // now attempt to join group
                 if (ev.success) {
-                    
+
                     if (currConnectionInfo.groupName.isNotEmpty()) {
-                        
+
                         currConnectionInfo.timestamp = Time::getCurrentTime().toMilliseconds();
-                        processor.addRecentServerConnectionInfo(currConnectionInfo);
-                        
+
+                        // Remember the ORIGINAL requested name as the
+                        // default for next time, even if this session
+                        // ended up connecting under a fallback name --
+                        // otherwise an auto-incremented name compounds
+                        // across future sessions/reconnects.
+                        if (retriedFromBaseUsername.isNotEmpty()) {
+                            AooServerConnectionInfo toRemember = currConnectionInfo;
+                            toRemember.userName = retriedFromBaseUsername;
+                            processor.addRecentServerConnectionInfo(toRemember);
+                        } else {
+                            processor.addRecentServerConnectionInfo(currConnectionInfo);
+                        }
+
                         processor.setWatchPublicGroups(false);
                         
                         processor.joinServerGroup(currConnectionInfo.groupName, currConnectionInfo.groupPassword, currConnectionInfo.groupIsPublic);

--- a/Source/SonobusPluginEditor.h
+++ b/Source/SonobusPluginEditor.h
@@ -215,6 +215,22 @@ private:
     
     String generateNewUsername(const AooServerConnectionInfo & info);
 
+    // Access-denied retry state for connectToServer: a login rejection
+    // (username already active) can mean either a genuinely different
+    // peer already holds that name, or our own prior session that the
+    // server hasn't timed out yet after a drop/restart. We can't tell
+    // these apart from a single rejection, so we retry the original
+    // name a few times before falling back to an auto-incremented one.
+    // mConnectRetryBaseUsername stays set for the whole retry+fallback
+    // sequence (cleared only on a definitive outcome) so a successful
+    // connect -- even under a fallback name -- still remembers the
+    // original name as the default for next time, rather than letting
+    // an incremented name compound across sessions.
+    String mConnectRetryBaseUsername;
+    int mConnectRetryCount = 0;
+    static constexpr int mConnectRetryMaxAttempts = 3;
+    static constexpr int mConnectRetryDelayMs = 2500;
+
 
 
     void openFileBrowser();


### PR DESCRIPTION
## Summary

When you reconnect after a dropped connection (network blip, app restart), you often come back into a group renamed to "Name 2" even though your original session is truly gone — not because someone else is using your name, but because the server hasn't timed out your own stale session yet.

The server's login (`get_user()` in `deps/aoo/lib/src/server.cpp`) returns a flat "access denied" for *any* username collision — it can't distinguish "someone else genuinely has this name" from "this is your own not-yet-expired session from a moment ago." The client currently treats every rejection as the former and immediately switches to an auto-incremented name on the very first failure.

This also compounds over time: the auto-incremented name gets saved as your new default username, so future connections start from "Name 2" already, and can creep further ("Name 3", etc.) on subsequent unlucky reconnects.

## Changes

- On "access denied," retry the *original* (un-suffixed) username up to 3 times (~2.5s apart, ~7.5s total) before falling back to the auto-incremented name — giving a same-device reconnect a real chance to reclaim its name once the server's stale session clears.
- Decoupled the persisted default username from whatever name a session actually ends up connecting with: even if a session falls back to "Name 2," the *original* requested name is what gets remembered for next time, not the fallback.

## Not included

No server-side changes. The AOO protocol has no in-session rename message, so reclaiming an already-active fallback session mid-session would require a disruptive disconnect/reconnect cycle — out of scope here; this only affects the initial-connect path.

## Testing

Built clean on both Linux and Windows (MSVC) with no new warnings, against a fresh checkout of `main`.